### PR TITLE
fix(ci): correct imposter commit SHA for ossf/scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- The pinned SHA `99c09fe` for `ossf/scorecard-action@v2.4.3` was flagged by GitHub's Scorecard webapp as an imposter commit not belonging to the `ossf/scorecard-action` repository
- Updated to the correct commit SHA `4eaacf0` from the actual [v2.4.3 release](https://github.com/ossf/scorecard-action/releases/tag/v2.4.3)

## Test plan
- [x] Manually trigger the Scorecard workflow (`workflow_dispatch`) and verify it completes without the `imposter commit` error