### PR TITLE
fix(deps): bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tbckr/trident
 
-go 1.26.3
+go 1.26.4
 
 require (
 	codeberg.org/miekg/dns v0.6.60


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from `1.26.3` to `1.26.4` to patch two Go **standard-library** vulnerabilities flagged by `govulncheck` (the failing *Scheduled Vulnerability Check* / `vuln` job):

- **GO-2026-5039** — `net/textproto`: arbitrary inputs included in errors without escaping (reached via `internal/input` → `bufio.Scanner.Scan` → `ReadMIMEHeader`).
- **GO-2026-5037** — `crypto/x509`: inefficient candidate hostname parsing (reached via `threatminer`/`dns` result formatting).

Both are fixed in **go1.26.4**. All CI jobs and GoReleaser resolve the toolchain via `go-version-file: go.mod`, so this single-line bump propagates everywhere.

## Verification (local, go1.26.4)

- `go build ./...` ✅
- `go test ./...` ✅
- `go mod tidy` → no extra diff ✅
- `govulncheck ./...` → **No vulnerabilities found** ✅

## ⚠️ Expected failure: `nix` job

nixpkgs-unstable still ships Go 1.26.3, and the flake builds with `buildGo126Module`/`go_1_26` from nixpkgs. Since `go.mod` now requires 1.26.4, the sandboxed `nix build`/`nix flake check` cannot fetch the newer toolchain and **will fail** — this is accepted and temporary.

**Follow-up** (separate `chore(nix)`): once `nixpkgs-unstable#go_1_26.version` reports `1.26.4`, run `just flake-update` (+ refresh `vendorHash` if needed) to re-green the `nix` job. Do not let `--auto` block on the nix check for this PR.