### PR TITLE
chore(deps): bump github/codeql-action from 4.36.3 to 4.37.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/betterleaks.yml
+++ b/.github/workflows/betterleaks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: betterleaks git . --report-format=sarif --report-path=betterleaks.sarif --redact --no-banner
 
-      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         if: always()
         with:
           sarif_file: betterleaks.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: go
 
-      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
 
-      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,6 +27,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run: semgrep scan --config=.semgrep --config=p/golang --config=p/gosec --sarif --output=semgrep.sarif --error --metrics=off
 
-      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         if: always()
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
Bumps all `github/codeql-action` sub-actions from v4.36.3 to v4.37.0 (SHA `54f647b` → `99df26d`) across all workflows in a single PR, replacing the four separate Dependabot PRs.

## Changes
- `codeql.yml` — `init`, `autobuild`, `analyze`
- `betterleaks.yml`, `semgrep.yml`, `scorecard.yml` — `upload-sarif`
- `dependabot.yml` — added a `codeql-action` group so future bumps stay in one PR

## Replaces / closes
- Closes #48 (init)
- Closes #49 (analyze)
- Closes #50 (upload-sarif)
- Closes #52 (autobuild)

## Test plan
- [ ] CI workflows (codeql, semgrep, betterleaks, scorecard) run green on this PR